### PR TITLE
simplify the default error handler

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -131,12 +131,7 @@ var ErrorHandler func(error) = DefaultErrorHandler
 
 // The DefaultErrorHandler prints the error with log.Printf
 func DefaultErrorHandler(err error) {
-	pe := PanicError{}
-	if errors.As(err, &pe) {
-		log.Printf("go routine panic: %+v", err)
-	} else {
-		log.Printf("go routine error: %+v", err)
-	}
+	log.Printf("%+v", err)
 }
 
 // Go is designed to use as an entry point to a go routine.


### PR DESCRIPTION
We don't know whether it is used in a Go routine

Also PanicError will generate a `panic: ` prefix now.